### PR TITLE
Updates core dependencies for Router

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,20 +1,12 @@
 buildscript {
   repositories {
+    mavenCentral()
     google()
-    jcenter()
   }
   dependencies {
     classpath(kotlin("gradle-plugin", version = Versions.Kotlin.lang))
     classpath(Deps.Android.gradle)
     classpath(Deps.KSP.classpath)
-  }
-}
-
-allprojects {
-  repositories {
-    google()
-    jcenter()
-    maven { setUrl("https://androidx.dev/snapshots/builds/7204104/artifacts/repository") }
   }
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  kotlin("jvm") version "1.4.30"
+  kotlin("jvm") version "1.4.32"
 }
 
 repositories {

--- a/buildSrc/src/main/java/Depencies.kt
+++ b/buildSrc/src/main/java/Depencies.kt
@@ -1,7 +1,7 @@
 object Versions {
   object Kotlin {
-    const val lang = "1.4.30"
-    const val ksp = "1.4.30-1.0.0-alpha05"
+    const val lang = "1.4.32"
+    const val ksp = "1.4.32-1.0.0-alpha07"
   }
 
   object Square {

--- a/crane-router/src/main/java/com/gabrielfv/crane/router/RouterWiringStep.kt
+++ b/crane-router/src/main/java/com/gabrielfv/crane/router/RouterWiringStep.kt
@@ -1,32 +1,33 @@
 package com.gabrielfv.crane.router
 
+import androidx.room.compiler.processing.XElement
 import androidx.room.compiler.processing.XProcessingEnv
 import androidx.room.compiler.processing.XProcessingStep
 import androidx.room.compiler.processing.XTypeElement
 import com.gabrielfv.crane.annotations.CraneRoot
 import com.gabrielfv.crane.annotations.internal.RouteRegistrar
 import com.gabrielfv.crane.router.generating.RouterBuilder
-import kotlin.reflect.KClass
 
 internal class RouterWiringStep(
   private val registrarFetcher: RegistrarFetcher,
   private val routerBuilder: RouterBuilder
 ) : XProcessingStep {
 
-  override fun annotations(): Set<KClass<out Annotation>> {
+  override fun annotations(): Set<String> {
     return setOf(
-      RouteRegistrar::class,
-      CraneRoot::class
+      RouteRegistrar::class.qName,
+      CraneRoot::class.qName
     )
   }
 
   override fun process(
     env: XProcessingEnv,
-    elementsByAnnotation: Map<KClass<out Annotation>, List<XTypeElement>>
-  ): Set<XTypeElement> {
-    val rootAnnotated = elementsByAnnotation[CraneRoot::class] ?: emptyList()
-    val localRegistrars = elementsByAnnotation[RouteRegistrar::class]
+    elementsByAnnotation: Map<String, Set<XElement>>
+  ): Set<XElement> {
+    val rootAnnotated = elementsByAnnotation[CraneRoot::class.qName] ?: emptyList()
+    val localRegistrars = elementsByAnnotation[RouteRegistrar::class.qName]
       ?.filter { it.isRouteRegistrar }
+      ?.map { it as XTypeElement }
       ?.toSet() ?: emptySet()
     val registrars = registrarFetcher.fetch(env, localRegistrars)
     val root = fetchRoot(env, rootAnnotated) ?: return emptySet()
@@ -35,11 +36,12 @@ internal class RouterWiringStep(
     return emptySet()
   }
 
-  private fun fetchRoot(env: XProcessingEnv, annotated: List<XTypeElement>): XTypeElement? {
+  private fun fetchRoot(env: XProcessingEnv, annotated: Collection<XElement>): XTypeElement? {
     if (annotated.size > 1) env.messager.e(
-      "Multiple ${CraneRoot::class.java.simpleName} found"
+      "Multiple ${CraneRoot::class.java.simpleName} instances found"
     )
     return annotated.firstOrNull()
+      ?.let { it as? XTypeElement }
   }
 
   private fun buildRouter(
@@ -54,8 +56,8 @@ internal class RouterWiringStep(
     routerBuilder.build(env.filer, registrarNames, pkg)
   }
 
-  private val XTypeElement.isRouteRegistrar: Boolean get() =
-    getSuperInterfaceElements().any {
+  private val XElement.isRouteRegistrar: Boolean get() =
+    this is XTypeElement && getSuperInterfaceElements().any {
       it.qualifiedName == RouterEnv.registrarInterfaceName.toString()
     }
 }

--- a/crane-router/src/main/java/com/gabrielfv/crane/router/RouterWiringStep.kt
+++ b/crane-router/src/main/java/com/gabrielfv/crane/router/RouterWiringStep.kt
@@ -53,7 +53,7 @@ internal class RouterWiringStep(
     val registrarNames = registrars
       .map { it.className.simpleName() }
       .toSet()
-    routerBuilder.build(env.filer, registrarNames, pkg)
+    routerBuilder.build(env.filer, registrarNames, pkg, root)
   }
 
   private val XElement.isRouteRegistrar: Boolean get() =

--- a/crane-router/src/main/java/com/gabrielfv/crane/router/generating/KtRouteRegistrarBuilder.kt
+++ b/crane-router/src/main/java/com/gabrielfv/crane/router/generating/KtRouteRegistrarBuilder.kt
@@ -2,6 +2,7 @@ package com.gabrielfv.crane.router.generating
 
 import androidx.room.compiler.processing.XFiler
 import androidx.room.compiler.processing.XTypeElement
+import androidx.room.compiler.processing.addOriginatingElement
 import androidx.room.compiler.processing.writeTo
 import com.gabrielfv.crane.annotations.internal.RouteRegistrar
 import com.gabrielfv.crane.router.RouterEnv
@@ -21,6 +22,11 @@ class KtRouteRegistrarBuilder : RouteRegistrarBuilder {
     if (routes.isEmpty()) return
     val fileBuilder = FileSpec.builder(RouterEnv.REGISTRARS_PACKAGE, className)
     val registrar = TypeSpec.classBuilder(className)
+      .apply {
+        originating.forEach {
+          addOriginatingElement(it)
+        }
+      }
       .addAnnotation(RouteRegistrar::class)
       .addSuperinterface(RouterEnv.registrarInterfaceName)
       .addFunction(

--- a/crane-router/src/main/java/com/gabrielfv/crane/router/kapt/JavacRouterProcessor.kt
+++ b/crane-router/src/main/java/com/gabrielfv/crane/router/kapt/JavacRouterProcessor.kt
@@ -19,7 +19,7 @@ class JavacRouterProcessor : BasicAnnotationProcessor() {
   private val routeRegistrarBuilder: RouteRegistrarBuilder =
     JavaRouteRegistrarBuilder()
 
-  override fun initSteps(): MutableIterable<ProcessingStep> {
+  override fun steps(): MutableIterable<Step> {
     return mutableSetOf(
       RoutingStep(routeRegistrarBuilder)
         .asAutoCommonProcessor(processingEnv),

--- a/crane-router/src/main/java/com/gabrielfv/crane/router/kapt/JavacRouterWiringProcessor.kt
+++ b/crane-router/src/main/java/com/gabrielfv/crane/router/kapt/JavacRouterWiringProcessor.kt
@@ -62,13 +62,14 @@ class JavacRouterWiringProcessor : BasicAnnotationProcessor() {
       val registrars = fetchRegistrars()
         .map { it.simpleName.toString() }
         .toSet()
-      val rootPackage = fetchRootPackage(elementsByAnnotation)
-      return if (rootPackage != null) {
+      val fetched = fetchRootPackage(elementsByAnnotation)
+      return if (fetched != null) {
+        val (rootElement, rootPackage) = fetched
         if (registrars.isNotEmpty()) {
-          buildRouterFile(registrars, rootPackage.second)
+          buildRouterFile(registrars, rootPackage, rootElement)
           mutableSetOf()
         } else {
-          mutableSetOf(rootPackage.first)
+          mutableSetOf(rootElement)
         }
       } else {
         mutableSetOf()
@@ -98,11 +99,11 @@ class JavacRouterWiringProcessor : BasicAnnotationProcessor() {
         }
     }
 
-    private fun buildRouterFile(names: Set<String>, rootPackage: String) {
+    private fun buildRouterFile(names: Set<String>, rootPackage: String, originating: Element) {
       if (names.isEmpty()) return
       if (rootPackage.isBlank()) return
       val file = FileBuilder.srcDir(processingEnv.kaptGeneratedSourcesDir)
-      builder.build(file, names, rootPackage)
+      builder.build(file, names, rootPackage, originating)
     }
   }
 }

--- a/crane-router/src/main/java/com/gabrielfv/crane/router/ksp/KspRouterProcessor.kt
+++ b/crane-router/src/main/java/com/gabrielfv/crane/router/ksp/KspRouterProcessor.kt
@@ -5,7 +5,6 @@ import com.gabrielfv.crane.router.ConfinedRegistrarFetcher
 import com.gabrielfv.crane.router.RegistrarFetcher
 import com.gabrielfv.crane.router.RouterWiringStep
 import com.gabrielfv.crane.router.RoutingStep
-import com.gabrielfv.crane.router.executeInKsp
 import com.gabrielfv.crane.router.generating.KtRouteRegistrarBuilder
 import com.gabrielfv.crane.router.generating.RouteRegistrarBuilder
 import com.gabrielfv.crane.router.generating.RouterBuilder
@@ -51,6 +50,6 @@ class KspRouterProcessor : SymbolProcessor {
     RoutingStep(routeRegistrarBuilder)
       .executeInKsp(processingEnv)
     return RouterWiringStep(registrarFetcher, routerBuilder)
-      .executeInKsp(processingEnv, resolver)
+      .executeInKsp(processingEnv)
   }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,10 @@
+dependencyResolutionManagement {
+  repositories {
+    google()
+    mavenCentral()
+    maven { setUrl("https://androidx.dev/snapshots/builds/7285896/artifacts/repository") }
+  }
+}
 include(
   ":crane",
   ":crane-annotations",


### PR DESCRIPTION
Changes:

```
Gradle: 6.8.2 -> 7.0
Kotlin: 1.4.30 -> 1.4.32
KSP: 1.4.30-1.0.0-alpha05 -> 1.4.32-1.0.0-alpha07
Room XProcessing: 2.4.0-SNAPSHOT Build 7204104 -> Build 7285896
```

Room XProcessing now:
- Integrates better with Auto Common `0.11`, which allows dropping the deprecated implementation in favor of a more up-to-date one.
- Returns the deferred elements in `XStep.executeInKsp()` method, which allows dropping the hacky extension temporary solution.

KSP now:
- Contains a `Resolver. getDeclarationsFromPackage()` API which can be used to make the project work in multiple modules, in a similar fashion to that of the KAPT processor. This is a greater change so it will be merged separately.