### PR TITLE
Sets jitpack to use JDK 11

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11


### PR DESCRIPTION
Build requires JDK 11, jitpack uses 8 as default.