### PR TITLE
Gradle 8.6

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,10 +4,8 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="GRADLE" />
-        <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="11" />
+        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
@@ -24,6 +22,7 @@
             <option value="$PROJECT_DIR$/samples/complete" />
           </set>
         </option>
+        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -13,7 +13,7 @@
       </map>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,17 +1,15 @@
-buildscript {
-  repositories {
-    mavenCentral()
-    google()
-  }
-  dependencies {
-    classpath(libs.kotlin.gradle)
-    classpath(libs.android.gradle)
-    classpath(libs.ksp.gradle)
-  }
+plugins {
+  alias(libs.plugins.kotlin.jvm) apply false
+  alias(libs.plugins.kotlin.android) apply false
+  alias(libs.plugins.kotlin.kapt) apply false
+  alias(libs.plugins.kotlin.parcelize) apply false
+  alias(libs.plugins.android.app) apply false
+  alias(libs.plugins.android.lib) apply false
+  alias(libs.plugins.ksp) apply false
 }
 
 tasks.register<Delete>("clean") {
-  delete(rootProject.buildDir)
+  delete(rootProject.layout.buildDirectory)
 }
 
 tasks.withType<Wrapper> {

--- a/crane-annotations/build.gradle.kts
+++ b/crane-annotations/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  kotlin("jvm")
+  alias(libs.plugins.kotlin.jvm)
   id("maven-publish")
 }
 

--- a/crane-router-tests/dummy-module-a/build.gradle.kts
+++ b/crane-router-tests/dummy-module-a/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-  kotlin("jvm")
-  kotlin("kapt")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.kapt)
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {

--- a/crane-router-tests/dummy-module-a/build.gradle.kts
+++ b/crane-router-tests/dummy-module-a/build.gradle.kts
@@ -10,10 +10,10 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach 
 }
 
 dependencies {
-  implementation(project(":crane-router-tests:fake-android"))
-  implementation(project(":crane-annotations"))
+  implementation(projects.craneRouterTests.fakeAndroid)
+  implementation(projects.craneAnnotations)
   implementation(kotlin("stdlib"))
-  kapt(project(":crane-router"))
+  kapt(projects.craneRouter)
 
   testImplementation(libs.ksp.impl)
 }

--- a/crane-router-tests/dummy-module-b/build.gradle.kts
+++ b/crane-router-tests/dummy-module-b/build.gradle.kts
@@ -10,9 +10,9 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach 
 }
 
 dependencies {
-  implementation(project(":crane-router-tests:fake-android"))
-  implementation(project(":crane-annotations"))
-  implementation(project(":crane-router-tests:dummy-module-a"))
+  implementation(projects.craneRouterTests.fakeAndroid)
+  implementation(projects.craneRouterTests.dummyModuleA)
+  implementation(projects.craneAnnotations)
   implementation(kotlin("stdlib"))
-  ksp(project(":crane-router"))
+  ksp(projects.craneRouter)
 }

--- a/crane-router-tests/dummy-module-b/build.gradle.kts
+++ b/crane-router-tests/dummy-module-b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-  kotlin("jvm")
-  id("com.google.devtools.ksp")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.ksp)
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {

--- a/crane-router-tests/fake-android/build.gradle.kts
+++ b/crane-router-tests/fake-android/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  kotlin("jvm")
+  alias(libs.plugins.kotlin.jvm)
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {

--- a/crane-router-tests/tests/build.gradle.kts
+++ b/crane-router-tests/tests/build.gradle.kts
@@ -9,8 +9,8 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach 
 }
 
 dependencies {
-  implementation(project(":crane-router"))
-  implementation(project(":crane-annotations"))
+  implementation(projects.craneRouter)
+  implementation(projects.craneAnnotations)
   implementation(kotlin("stdlib"))
   implementation(libs.ksp.api)
   implementation(libs.google.auto.common)
@@ -20,8 +20,8 @@ dependencies {
   implementation(libs.junit)
   implementation(libs.assertj)
 
-  testImplementation(project(":crane-router-tests:fake-android"))
-  testImplementation(project(":crane-router-tests:dummy-module-a"))
-  testImplementation(project(":crane-router-tests:dummy-module-b"))
+  testImplementation(projects.craneRouterTests.fakeAndroid)
+  testImplementation(projects.craneRouterTests.dummyModuleA)
+  testImplementation(projects.craneRouterTests.dummyModuleB)
   testImplementation(libs.ksp.impl)
 }

--- a/crane-router-tests/tests/build.gradle.kts
+++ b/crane-router-tests/tests/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  kotlin("jvm")
+  alias(libs.plugins.kotlin.jvm)
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {

--- a/crane-router/build.gradle.kts
+++ b/crane-router/build.gradle.kts
@@ -24,7 +24,7 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach 
 }
 
 dependencies {
-  implementation(project(":crane-annotations"))
+  implementation(projects.craneAnnotations)
   implementation(kotlin("stdlib"))
   implementation(kotlin("compiler-embeddable"))
   implementation(libs.ksp.api)

--- a/crane/build.gradle.kts
+++ b/crane/build.gradle.kts
@@ -25,7 +25,7 @@ android {
 }
 
 dependencies {
-  api(project(":crane-annotations"))
+  api(projects.craneAnnotations)
   implementation(kotlin("stdlib"))
   implementation(libs.bundles.androidx)
 

--- a/crane/build.gradle.kts
+++ b/crane/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-  id("com.android.library")
-  kotlin("android")
+  alias(libs.plugins.android.lib)
+  alias(libs.plugins.kotlin.android)
   id("maven-publish")
 }
 
@@ -11,7 +11,6 @@ android {
 
   defaultConfig {
     minSdk = 11
-    targetSdk = 31
   }
   testOptions {
     unitTests.isReturnDefaultValues = true

--- a/crane/build.gradle.kts
+++ b/crane/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 android {
   compileSdk = 31
   buildToolsVersion = "31.0.0"
+  namespace = "com.gabrielfv.crane"
 
   defaultConfig {
     minSdk = 11

--- a/crane/src/main/AndroidManifest.xml
+++ b/crane/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.gabrielfv.crane" />
+<manifest />

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,11 +16,8 @@ mockk = "1.10.6"
 assertj = "3.21.0"
 
 [libraries]
-kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-ksp-gradle = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version.ref = "ksp" }
 ksp-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
 ksp-impl = { module = "com.google.devtools.ksp:symbol-processing", version.ref = "ksp" }
-android-gradle = { module = "com.android.tools.build:gradle", version.ref = "android-gradle" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 androidx-corektx = { module = "androidx.core:core-ktx", version.ref = "androidx-corektx" }
 androidx-room-processing = { module = "androidx.room:room-compiler-processing", version.ref = "androidx-room-processing" }
@@ -38,3 +35,12 @@ assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 
 [bundles]
 androidx = ["androidx-appcompat", "androidx-corektx"]
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
+kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
+android-app = { id = "com.android.application", version.ref = "android-gradle" }
+android-lib = { id = "com.android.library", version.ref = "android-gradle" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "1.6.10"
 ksp = "1.6.10-1.0.2"
-android-gradle = "7.0.4"
+android-gradle = "8.2.2"
 androidx-appcompat = "1.2.0"
 androidx-corektx = "1.3.2"
 androidx-room-processing = "2.4.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/samples/basic/build.gradle.kts
+++ b/samples/basic/build.gradle.kts
@@ -1,8 +1,7 @@
 plugins {
-  id("com.android.application")
-  kotlin("android")
-  id("kotlin-parcelize")
-  id("kotlin-android")
+  alias(libs.plugins.android.app)
+  alias(libs.plugins.kotlin.android)
+  alias(libs.plugins.kotlin.parcelize)
 }
 
 android {

--- a/samples/basic/build.gradle.kts
+++ b/samples/basic/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 android {
   compileSdk = 30
   buildToolsVersion = "31.0.0"
+  namespace = "com.gabrielfv.basicsample"
 
   defaultConfig {
     minSdk = 16

--- a/samples/basic/build.gradle.kts
+++ b/samples/basic/build.gradle.kts
@@ -47,7 +47,7 @@ android {
 
 dependencies {
 
-  implementation(project(":crane"))
+  implementation(projects.crane)
   implementation(kotlin("stdlib"))
   implementation("androidx.core:core-ktx:1.3.2")
   implementation("androidx.appcompat:appcompat:1.2.0")

--- a/samples/basic/src/main/AndroidManifest.xml
+++ b/samples/basic/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.gabrielfv.basicsample">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/samples/complete/build.gradle.kts
+++ b/samples/complete/build.gradle.kts
@@ -1,9 +1,8 @@
 plugins {
-  id("com.android.application")
-  kotlin("android")
-  kotlin("kapt")
-  id("kotlin-parcelize")
-  id("kotlin-android")
+  alias(libs.plugins.android.app)
+  alias(libs.plugins.kotlin.android)
+  alias(libs.plugins.kotlin.parcelize)
+  alias(libs.plugins.kotlin.kapt)
 }
 
 android {

--- a/samples/complete/build.gradle.kts
+++ b/samples/complete/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
 android {
   compileSdk = 31
   buildToolsVersion = "31.0.0"
+  namespace = "com.gabrielfv.samples.complete"
 
   defaultConfig {
     minSdk = 26 // java.time without desugar

--- a/samples/complete/build.gradle.kts
+++ b/samples/complete/build.gradle.kts
@@ -57,8 +57,8 @@ android {
 
 dependencies {
 
-  implementation(project(":crane"))
-  kapt(project(":crane-router"))
+  implementation(projects.crane)
+  kapt(projects.craneRouter)
   implementation(kotlin("stdlib"))
   implementation("androidx.core:core-ktx:1.7.0")
   implementation("androidx.appcompat:appcompat:1.4.0")

--- a/samples/complete/src/main/AndroidManifest.xml
+++ b/samples/complete/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.gabrielfv.samples.complete">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:name=".SampleApp"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,13 @@
+pluginManagement {
+  repositories {
+    google()
+    mavenCentral()
+    gradlePluginPortal()
+  }
+}
+@Suppress("UnstableApiUsage")
 dependencyResolutionManagement {
-  repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+  repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
   repositories {
     google()
     mavenCentral()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,3 @@
-@file:Suppress("UnstableApiUsage")
-enableFeaturePreview("VERSION_CATALOGS")
 dependencyResolutionManagement {
   repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
   repositories {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
+rootProject.name = "crane-lib"  // Required for project accessors
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 pluginManagement {
   repositories {
     google()


### PR DESCRIPTION
[Updates Gradle to 8.6 (AGP -> 8.2.2)](https://github.com/gfreivasc/crane/commit/830379e4f79d22de55d0f5645bf4c756395bdb72)

[Update Version Catalogs usage](https://github.com/gfreivasc/crane/commit/c6bc76fa0b70a19270ec30a8eb540107e1a604c5)

* Start using the [plugin] clause and some reference cleaning up

[Enables Type-safe project accessors](https://github.com/gfreivasc/crane/commit/5042a0f6db05d4e4ba1c2c98ec0995fb994bdb10)

* Renames project to `crane-lib` to avoid conflicts with `:crane` module.